### PR TITLE
Use --is-ancestor for --no-ff merge

### DIFF
--- a/dist/entrypoint.js
+++ b/dist/entrypoint.js
@@ -36,8 +36,9 @@ const tools = new actions_toolkit_1.Toolkit({
         return acc;
     }, {});
     const currentLabelNames = new Set(result.repository.pullRequest.labels.edges.map((edge) => edge.node.name));
+    const { headRefOid, baseRefOid } = result.repository.pullRequest;
     // TODO: handle stderr
-    const { stdout, stderr } = await exec(`git diff --name-only $(git merge-base ${result.repository.pullRequest.headRefOid} ${result.repository.pullRequest.baseRefOid})`);
+    const { stdout, stderr } = await exec(`git merge-base --is-ancestor ${baseRefOid} ${headRefOid} && git diff --name-only ${baseRefOid} || git diff --name-only $(git merge-base ${baseRefOid} ${headRefOid})`);
     const diffFiles = stdout.trim().split('\n');
     const newLabelNames = new Set(diffFiles.reduce((acc, file) => {
         Object.entries(config.rules).forEach(([label, pattern]) => {

--- a/src/entrypoint.ts
+++ b/src/entrypoint.ts
@@ -49,11 +49,11 @@ const tools = new Toolkit({
     ),
   );
 
+  const { headRefOid, baseRefOid } = result.repository.pullRequest;
+
   // TODO: handle stderr
   const { stdout, stderr } = await exec(
-    `git diff --name-only $(git merge-base ${
-      result.repository.pullRequest.headRefOid
-    } ${result.repository.pullRequest.baseRefOid})`,
+    `git merge-base --is-ancestor ${baseRefOid} ${headRefOid} && git diff --name-only ${baseRefOid} || git diff --name-only $(git merge-base ${baseRefOid} ${headRefOid})`,
   );
 
   const diffFiles = stdout.trim().split('\n');


### PR DESCRIPTION
otherwise, this doesn't work when `git merge` with `no-ff` is used. 

1. Check if `git merge-base --is-ancestor A B` A is ancestor of B. 
2. if true, only the diff from `git diff --name-only A`. 
3. if false, get merge point of commit: `git diff --name-only $(git merge-base ${baseRefOid} ${headRefOid})`